### PR TITLE
small change in the path of get animal

### DIFF
--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -100,7 +100,7 @@ functions:
     events:
       - http:
           method: get
-          path: animals/{animalName}/{shelterName}
+          path: animal/{animalName}/{shelterName}
           cors: true
     iamRoleStatements:
       - Effect: Allow


### PR DESCRIPTION
endpoint had a spelling error. It must have been 
`https://idvmpyv72b.execute-api.us-east-1.amazonaws.com/dev/**animal**/:animalName/:shelterName` instead of 
`https://idvmpyv72b.execute-api.us-east-1.amazonaws.com/dev/**animals**/:animalName/:shelterName`
![Screen Shot 2022-02-21 at 9 17 33 PM](https://user-images.githubusercontent.com/52226049/155067687-fc8d790a-1448-4421-88ed-c2770e58f80d.png)

