### PR TITLE
image routes for user and animal avatar

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -17,6 +17,7 @@
                 "http-errors": "^1.7.2",
                 "jsonwebtoken": "^8.5.1",
                 "middy": "^0.27.0",
+                "serverless-plugin-additional-stacks": "^1.6.0",
                 "source-map-support": "^0.5.11",
                 "uuid": "^3.3.2",
                 "winston": "^3.2.1"
@@ -2696,7 +2697,6 @@
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
-                "fsevents": "~2.3.2",
                 "glob-parent": "~5.1.2",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -5782,7 +5782,6 @@
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "dependencies": {
-                "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             },
             "optionalDependencies": {
@@ -6055,6 +6054,11 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+        },
+        "node_modules/lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "node_modules/lodash.once": {
             "version": "4.1.1",
@@ -8064,6 +8068,17 @@
                 "node": ">=10"
             }
         },
+        "node_modules/serverless-plugin-additional-stacks": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-additional-stacks/-/serverless-plugin-additional-stacks-1.6.0.tgz",
+            "integrity": "sha512-ucoJlMY7oSiXhLjdq+Pnr5o3siJ3VyCS7mGKKIGsMFO759YDHL2+6qiRilrmqOWoM3ipIjhl7XMvPar5hrLI5Q==",
+            "dependencies": {
+                "lodash.merge": "^4.6.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/serverless-plugin-canary-deployments": {
             "version": "0.4.8",
             "resolved": "https://registry.npmjs.org/serverless-plugin-canary-deployments/-/serverless-plugin-canary-deployments-0.4.8.tgz",
@@ -8134,8 +8149,7 @@
                 "glob": "^7.2.0",
                 "is-builtin-module": "^3.1.0",
                 "lodash": "^4.17.21",
-                "semver": "^7.3.5",
-                "ts-node": ">= 8.3.0"
+                "semver": "^7.3.5"
             },
             "engines": {
                 "node": ">= 10.12.0"
@@ -9950,10 +9964,8 @@
             "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
             "dev": true,
             "dependencies": {
-                "chokidar": "^3.4.1",
                 "graceful-fs": "^4.1.2",
-                "neo-async": "^2.5.0",
-                "watchpack-chokidar2": "^2.0.1"
+                "neo-async": "^2.5.0"
             },
             "optionalDependencies": {
                 "chokidar": "^3.4.1",
@@ -10050,7 +10062,6 @@
                 "anymatch": "^2.0.0",
                 "async-each": "^1.0.1",
                 "braces": "^2.3.2",
-                "fsevents": "^1.2.7",
                 "glob-parent": "^3.1.0",
                 "inherits": "^2.0.3",
                 "is-binary-path": "^1.0.0",
@@ -15907,6 +15918,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
             "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
         },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        },
         "lodash.once": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -17576,6 +17592,14 @@
             "dev": true,
             "requires": {
                 "lodash": "^4.17.20"
+            }
+        },
+        "serverless-plugin-additional-stacks": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/serverless-plugin-additional-stacks/-/serverless-plugin-additional-stacks-1.6.0.tgz",
+            "integrity": "sha512-ucoJlMY7oSiXhLjdq+Pnr5o3siJ3VyCS7mGKKIGsMFO759YDHL2+6qiRilrmqOWoM3ipIjhl7XMvPar5hrLI5Q==",
+            "requires": {
+                "lodash.merge": "^4.6.2"
             }
         },
         "serverless-plugin-canary-deployments": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
         "http-errors": "^1.7.2",
         "jsonwebtoken": "^8.5.1",
         "middy": "^0.27.0",
+        "serverless-plugin-additional-stacks": "^1.6.0",
         "source-map-support": "^0.5.11",
         "uuid": "^3.3.2",
         "winston": "^3.2.1"

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -20,6 +20,8 @@ provider:
     USER_TABLE: Beasties-user-${self:provider.stage}
     ANIMAL_TABLE: Beasties-animal-${self:provider.stage}
     USER_ANIMAL_REQUESTS_TABLE: Beasties-request-${self:provider.stage}
+    IMAGES_S3_BUCKET: beasties-s3-images-${self:provider.stage}
+    SIGNED_URL_EXPIRATION: 300
   
   tracing:
     lambda: true
@@ -52,6 +54,10 @@ custom:
       - name: UpdateAnimal
         contentType: application/json
         schema: ${file(models/update-animal.json)}
+  splitStacks:
+    perFunction: false
+    perType: true
+    perGroupFunction: false
 
 functions:
   
@@ -401,6 +407,24 @@ functions:
         Action:
           - execute-api:Invoke
         Resource: arn:aws:execute-api:*:*:*
+  
+  GenerateUploadUrl:
+    handler: src/lambda/http/generateUploadUrl.handler
+    events:
+      - http:
+          method: post
+          path: images/user/{imageKey}
+          cors: true
+      - http:
+          method: post
+          path: images/animal/{imageKey}
+          cors: true
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - s3:PutObject
+          - s3:GetObject
+        Resource: arn:aws:s3:::${self:provider.environment.IMAGES_S3_BUCKET}/*
 
 resources:
   Resources:
@@ -472,6 +496,42 @@ resources:
             Projection:
               ProjectionType: ALL
         BillingMode: PAY_PER_REQUEST
+
+    #Images-Bucket
+    AttachmentsBucket:
+      Type: AWS::S3::Bucket
+      Properties:
+        BucketName: ${self:provider.environment.IMAGES_S3_BUCKET}
+        CorsConfiguration:
+          CorsRules:
+            -
+              AllowedOrigins:
+                - '*'
+              AllowedHeaders:
+                - '*'
+              AllowedMethods:
+                - GET
+                - PUT
+                - POST
+                - DELETE
+                - HEAD
+              MaxAge: 3000
+
+    BucketPolicy:
+      Type: AWS::S3::BucketPolicy
+      Properties:
+        PolicyDocument:
+          Id: MyPolicy
+          Version: "2012-10-17"
+          Statement:
+            - Sid: PublicReadForGetBucketObjects
+              Effect: Allow
+              Principal: '*'
+              Action: 
+                - 's3:GetObject'
+                - 's3:PutObject'
+              Resource: 'arn:aws:s3:::${self:provider.environment.IMAGES_S3_BUCKET}/*'
+        Bucket: !Ref AttachmentsBucket
 
     #Request body validator
     RequestBodyValidator:

--- a/backend/src/businessLogic/beastiesAnimalLogic.ts
+++ b/backend/src/businessLogic/beastiesAnimalLogic.ts
@@ -1,5 +1,6 @@
 import { APIGatewayProxyEvent } from 'aws-lambda'
 import { AnimalTableAccess } from '../dataLayer/animalTableAccess'
+import { BeastiesS3Access } from '../dataLayer/beastiesS3Access'
 import { AnimalItem } from '../modals/AnimalItem'
 
 import { CreateAnimalAPIRequest } from '../requests/CreateAnimalAPIRequest'
@@ -7,6 +8,8 @@ import { UpdateAnimal } from '../requests/UpdateAnimal'
 import { createLogger } from '../utils/logger'
 
 const animalAccess = new AnimalTableAccess()
+const beastiesS3Access = new BeastiesS3Access()
+
 const logger = createLogger('Beasties BusinessLogic Execution')
 
 export async function createAnimal(event: APIGatewayProxyEvent, createAnimalRequest: CreateAnimalAPIRequest) : Promise<CreateAnimalAPIRequest> {
@@ -21,6 +24,7 @@ export async function createAnimal(event: APIGatewayProxyEvent, createAnimalRequ
 
     const animalItem = {
         animalName_shelterName: animal_shelter,
+        avatar: `http://${beastiesS3Access.getBucketName()}.s3.amazonaws.com/animal/${animal_shelter}`,
         ...createAnimalRequest
     }
     logger.info('Adding a pet animal to dynamodb')

--- a/backend/src/businessLogic/beastiesS3Logic.ts
+++ b/backend/src/businessLogic/beastiesS3Logic.ts
@@ -1,0 +1,37 @@
+import {APIGatewayProxyEvent} from 'aws-lambda'
+
+import { BeastiesS3Access } from '../dataLayer/beastiesS3Access'
+import { createLogger } from '../utils/logger'
+
+const beastiesS3Access = new BeastiesS3Access()
+const logger = createLogger('Beasties S3 BusinessLogic Execution')
+
+export async function generateUploadUrl(event: APIGatewayProxyEvent) {
+
+    const beastiesS3BucketName = beastiesS3Access.getBucketName()
+    const imageKey = event.pathParameters.imageKey
+    let paramsKey: string;
+    // console.log(event);
+    
+    if(event.path.includes("user")){
+        // console.log("Im in user")
+        paramsKey = `user/${imageKey}`
+    }
+    if(event.path.includes("animal")){
+        // console.log("Im in animal")
+        paramsKey = `animal/${imageKey}`
+    }
+    console.log(paramsKey);
+    const urlExpiration = 3000
+    
+    logger.info(`Getting Upload URL for post ${imageKey}`)
+
+    const createSignedURLRequest = {
+        Bucket: beastiesS3BucketName,
+        Key: paramsKey,
+        ContentType: 'image/png',
+        Expires: urlExpiration
+    }
+    return await beastiesS3Access.getPreSignedUploadURL(createSignedURLRequest)
+
+}

--- a/backend/src/businessLogic/beastiesUserLogic.ts
+++ b/backend/src/businessLogic/beastiesUserLogic.ts
@@ -5,14 +5,19 @@ import { CreateUserAPIRequest } from '../requests/CreateUserAPIRequest'
 import { UserItem } from '../modals/UserItem'
 import { createLogger } from '../utils/logger'
 import { UpdateUser } from '../requests/UpdateUser'
+import { BeastiesS3Access } from '../dataLayer/beastiesS3Access'
 
 const userAccess = new UserTableAccess()
+const beastiesS3Access = new BeastiesS3Access()
+
 const logger = createLogger('Beasties BusinessLogic Execution')
 
 export async function createUser(createUserRequest: CreateUserAPIRequest) : Promise<CreateUserAPIRequest> {
     
     logger.info(`Executing logic for createUser API request ${createUserRequest}`)
+    const userName = createUserRequest['userName']
     const userItem = {
+        avatar: `http://${beastiesS3Access.getBucketName()}.s3.amazonaws.com/user/${userName}`,  
         ...createUserRequest
     }
     logger.info('Adding a user to dynamodb')

--- a/backend/src/dataLayer/beastiesS3Access.ts
+++ b/backend/src/dataLayer/beastiesS3Access.ts
@@ -1,0 +1,33 @@
+import {CreateSignedURLRequest} from '../requests/CreateSignedURLRequest'
+
+import * as AWS from 'aws-sdk'
+
+// # References
+
+// https://github.com/vturbin/Serverless-Project
+// https://github.com/mu-majid/serverless-todo-app
+
+export class BeastiesS3Access {
+    constructor(
+        private readonly beastiesS3BucketName = process.env.IMAGES_S3_BUCKET,
+        private readonly s3 = new AWS.S3()
+    ) {}
+
+    getBucketName() {
+        return this.beastiesS3BucketName
+    }
+    
+    getPreSignedUploadURL(createSignedURLRequest) {
+        return this.s3.getSignedUrl(
+            'putObject',
+            createSignedURLRequest    
+        )
+    }
+
+    getPreSignedGetURL(createSignedURLRequest: CreateSignedURLRequest) {
+        return this.s3.getSignedUrl(
+            'getObject',
+            createSignedURLRequest
+        )
+    }
+}

--- a/backend/src/lambda/http/generateUploadUrl.ts
+++ b/backend/src/lambda/http/generateUploadUrl.ts
@@ -1,0 +1,28 @@
+import 'source-map-support/register'
+
+import { APIGatewayProxyEvent, APIGatewayProxyResult, APIGatewayProxyHandler } from 'aws-lambda'
+import { generateUploadUrl } from '../../businessLogic/beastiesS3Logic'
+
+import {createLogger} from '../../utils/logger'
+
+const logger = createLogger('Generate SignedURL')
+
+export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  
+  logger.info( `Processing generateSignedURL event ${JSON.stringify(event)}`)
+  
+  const signedURL = await generateUploadUrl(event)
+  
+  logger.info(`Signed url - ${signedURL}`)
+
+  return {
+    statusCode: 202,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true
+    },
+    body: JSON.stringify({
+      uploadUrl: signedURL
+    })
+  }
+}

--- a/backend/src/requests/CreateAnimalAPIRequest.ts
+++ b/backend/src/requests/CreateAnimalAPIRequest.ts
@@ -8,6 +8,5 @@ export interface CreateAnimalAPIRequest {
     gender: string
     shelterName: string
     animalName_shelterName: string
-    avatar: string
     imageCollections: string[]
 }

--- a/backend/src/requests/CreateSignedURLRequest.ts
+++ b/backend/src/requests/CreateSignedURLRequest.ts
@@ -1,0 +1,7 @@
+// References:
+// https://github.com/vturbin/Serverless-Project
+export interface CreateSignedURLRequest {
+    Bucket: string,
+    Key: string,
+    Expires: number
+}

--- a/backend/src/requests/CreateUserAPIRequest.ts
+++ b/backend/src/requests/CreateUserAPIRequest.ts
@@ -8,5 +8,5 @@
     zipcode: string
     isShelterOwner: boolean
     shelterName: string
-    avatar: string
+    // avatar: string
   }


### PR DESCRIPTION
Created a s3 resource and lambda function to upload photos to it.
I have changed the 'create-user' and 'create-animal' routes to generate the image URL for the corresponding user/animal. So, everytime a user/animal is created, it will auto-generate the bucket link. No changes are need to be done from the front-end. (Just no need to send anything for 'avatar' in the create request body)

Routes created for uploading or changing a photo to the bucket:
1. POST - https://idvmpyv72b.execute-api.us-east-1.amazonaws.com/dev/images/animal/:imageKey (Should send the `animalName_shelterName` for the animal's imageKey)
3. POST- https://idvmpyv72b.execute-api.us-east-1.amazonaws.com/dev/images/user/:imageKey (Should send the `userName` for the user's imageKey)

The call to the post route will generate a pre-signed URL (POST request). 
We pass the URL along with the file to upload the image to the corresponding bucket folder ( must be a PUT request). 

The api call for uploading image to user from the frontend will look like:
```
  const response = await Axios.post(`images/user/${imageKey}`, '', {
    headers: {
      'Content-Type': 'application/json'
    }
  })
```
```
  await Axios.put(uploadUrl, file)
```
![Screen Shot 2022-03-05 at 10 01 48 AM](https://user-images.githubusercontent.com/52226049/156895848-155bc23c-07f5-4c87-b75c-db9a9240e2ba.png)
![Screen Shot 2022-03-05 at 10 00 07 AM](https://user-images.githubusercontent.com/52226049/156895871-d14046da-6480-4735-a40f-93cb9218d331.png)
![Screen Shot 2022-03-05 at 10 01 08 AM](https://user-images.githubusercontent.com/52226049/156895878-b91bcd3f-eb5f-4246-88a5-d895d80cf309.png)
![Screen Shot 2022-03-05 at 10 02 01 AM](https://user-images.githubusercontent.com/52226049/156895882-f7c1ae0e-b3be-42ed-ba42-4f3984131f25.png)

